### PR TITLE
fix: RUSTSEC-2026-0037 (quinn-proto vulnerability)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Updates quinn-proto from 0.11.13 to 0.11.14 to fix a denial of service vulnerability.